### PR TITLE
Don't convert quotes when Vim is not inserting

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
             {
                 "key": "shift+[",
                 "command": "backticks.convertQuotes",
-                "when": "editorTextFocus"
+                "when": "editorTextFocus && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
             }
         ]
     },


### PR DESCRIPTION
The Vim plugin uses the { key as a motion key, except in insert mode. This change makes this extension only convert quotes when Vim is not in an insert mode. Since the variable `vim.mode` is not defined when the Vim extension is not installed, a very long list of modes that should suppress this extension is used. That way quote replacing behavior works both with and without the Vim extension installed.

There may be a simpler way to express this, but I couldn't get the key binding `when` clause to allow nested boolean statemets in my testing. If nested boolean statements worked, something like `(vim.mode == undefined || vim.mode == "Insert" || vim.mode == "Replace" || vim.mode == "Disabled")` would be shorter and should work.